### PR TITLE
emit CSV relation which is compatible with SPARQL CSV format

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,10 +146,9 @@ libraptor2_la_SOURCES += raptor_serialize_rdfxmla.c
 endif
 if RAPTOR_SERIALIZER_TURTLE
 libraptor2_la_SOURCES += raptor_serialize_turtle.c
-else
+endif
 if RAPTOR_SERIALIZER_MKR
 libraptor2_la_SOURCES += raptor_serialize_turtle.c
-endif
 endif
 if RAPTOR_SERIALIZER_RSS_1_0
 libraptor2_la_SOURCES += raptor_serialize_rss.c

--- a/src/raptor_internal.h
+++ b/src/raptor_internal.h
@@ -1333,6 +1333,7 @@ RAPTOR_INTERNAL_API void raptor_turtle_writer_decrease_indent(raptor_turtle_writ
 RAPTOR_INTERNAL_API void raptor_turtle_writer_newline(raptor_turtle_writer *turtle_writer);
 RAPTOR_INTERNAL_API int raptor_turtle_writer_reference(raptor_turtle_writer* turtle_writer, raptor_uri* uri);
 RAPTOR_INTERNAL_API int raptor_turtle_writer_literal(raptor_turtle_writer* turtle_writer, raptor_namespace_stack *nstack, const unsigned char *s, const unsigned char* lang, raptor_uri* datatype);
+RAPTOR_INTERNAL_API void raptor_turtle_writer_csv_string(raptor_turtle_writer* turtle_writer, const unsigned char *s);
 RAPTOR_INTERNAL_API void raptor_turtle_writer_qname(raptor_turtle_writer* turtle_writer, raptor_qname* qname);
 RAPTOR_INTERNAL_API int raptor_turtle_writer_quoted_counted_string(raptor_turtle_writer* turtle_writer, const unsigned char *s, size_t length);
 void raptor_turtle_writer_comment(raptor_turtle_writer* turtle_writer, const unsigned char *s);

--- a/src/raptor_turtle_writer.c
+++ b/src/raptor_turtle_writer.c
@@ -124,6 +124,39 @@ raptor_turtle_writer_newline(raptor_turtle_writer *turtle_writer)
 }
 
 
+void
+raptor_turtle_writer_csv_string(raptor_turtle_writer *turtle_writer,
+                                const unsigned char *string)
+{
+  raptor_iostream *iostr = turtle_writer->iostr;
+  size_t len = strlen(string);
+  const char delim = '\x22';
+  int quoting_needed = 0;
+  size_t i;
+
+  for(i = 0; i < len; i++) {
+    char c = string[i];
+    /* Quoting needed for delim (double quote), comma, linefeed or return */
+    if(c == delim   || c == ',' || c == '\r' || c == '\n') {
+      quoting_needed++;
+      break;
+    }
+  }
+  if(!quoting_needed)
+    return raptor_iostream_counted_string_write(string, len, iostr);
+
+  raptor_iostream_write_byte(delim, iostr);
+  for(i = 0; i < len; i++) {
+    char c = string[i];
+    if(c == delim)
+      raptor_iostream_write_byte(delim, iostr);
+    raptor_iostream_write_byte(c, iostr);
+  }
+  raptor_iostream_write_byte(delim, iostr);
+
+  return;
+}
+
 /**
  * raptor_new_turtle_writer:
  * @world: raptor_world object

--- a/tests/mkr/rdfq-results.mkr
+++ b/tests/mkr/rdfq-results.mkr
@@ -2,16 +2,12 @@
 @prefix rdf: <../../../../../1999/02/22-rdf-syntax-ns#> ;
 @prefix rs: <http://jena.hpl.hp.com/2003/03/result-set#> ;
 
-<> has
-    rs:resultVariable = ["x", "y"], 
-    rs:size = [4] ;
 result is <> ;
-result is relation with
-    format = [value:1, value:2], 
-    meaning = {x := $1; y := $2;} ;
+result is relation with format = csv ;
 begin relation result ;
-"anon2", _:a ;
+x, y ;
+anon2, _:a ;
 123, <http://example.com/resource1> ;
-"2003-01-21", <http://example.com/resource2> ;
-"anon1", _:a ;
+2003-01-21, <http://example.com/resource2> ;
+anon1, _:a ;
 end relation result ;


### PR DESCRIPTION
The details of the "format" and "meaning" properties of the mKR relation have been moved into the mKE program. mKE supplies default values for those properties.  The mKE user can supply custom values  which override the defaults to provide any desired translation function from bound variables to sentences.
