### PR TITLE
Fixing build errors using raptor2.spec

### DIFF
--- a/raptor2.spec.in
+++ b/raptor2.spec.in
@@ -85,10 +85,10 @@ install -d $RPM_BUILD_ROOT%{_mandir}/man3
 %doc AUTHORS COPYING COPYING.LIB ChangeLog LICENSE.txt NEWS README
 %doc LICENSE-2.0.txt NOTICE
 
-%{_libdir}/libraptor*.so
+%{_libdir}/libraptor2*.*
 %{_libdir}/pkgconfig/raptor2.pc
 
-%{prefix}/include/raptor/*
+%{prefix}/include/raptor2/*
 
 
 %changelog

--- a/raptor2.spec.in
+++ b/raptor2.spec.in
@@ -92,6 +92,9 @@ install -d $RPM_BUILD_ROOT%{_mandir}/man3
 
 
 %changelog
+* Wed Jan 14 2015  Phil John <philjohn@gmail.com>
+- Fix for wrong libdir causing errors when running rpmbuild
+
 * Fri Jan 5 2007  Dave Beckett <dave@dajobe.org>
 - rename files for raptor 2.0.0
 - no more raptor-config


### PR DESCRIPTION
The spec file uses the wrong libdir for raptor2, /usr/lib(|64)/raptor instead of /usr/lib(|64)/raptor2, it also excludes some files (.a and .la) that rpmbuild complains about.