### PR TITLE
configure.ac: do additional checks on libxml2 when library is found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -599,7 +599,7 @@ have_libxml=0
 need_libxml=0
 
 oCPPFLAGS="$CPPFLAGS"
-if test "X$XML_CONFIG" != X; then
+if test "X$libxml_source" != X; then
   CPPFLAGS="$LIBXML_CFLAGS $CPPFLAGS"
   LIBS="$LIBS $LIBXML_LIBS"
   AC_CHECK_FUNC(xmlCreatePushParserCtxt, have_xmlCreatePushParserCtxt=yes, have_xmlCreatePushParserCtxt=no)


### PR DESCRIPTION
In yocto cross environments we must use pkg-config. Configuring with

  --without-xml2-config
  --without-curl-config

causes

| checking for LIBXML... yes
| checking for libxml via pkg-config... yes - 2.9.2
| checking for LIBCURL... yes
| checking for libcurl via pkg-config... yes - 7.44.0
| checking for ICU... no
| checking for yajl installation... not found. Get it from http://lloyd.github.com/yajl/ and use --with-yajl=DIR if necessary to configure the installation directory.
| checking GRDDL parser requirements... no - libxml2 and libxslt are both not available

Applying this patch fixes configuration.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>