### PR TITLE
Change to count option of rapper to count in longs instead of ints

### DIFF
--- a/utils/rapper.c
+++ b/utils/rapper.c
@@ -76,7 +76,7 @@ static int quiet = 0;
 /* just count, no printing */
 static int count = 0;
 
-static int triple_count = 0;
+static long triple_count = 0;
 
 static raptor_serializer* serializer = NULL;
 
@@ -940,7 +940,7 @@ main(int argc, char *argv[])
       fprintf(stderr, "%s: Parsing returned 1 triple\n",
               program);
     else
-      fprintf(stderr, "%s: Parsing returned %d triples\n",
+      fprintf(stderr, "%s: Parsing returned %ld triples\n",
               program, triple_count);
   }
   


### PR DESCRIPTION
Very simple change that just changes the triple_count variable from an int to a long. Hoping that on most architectures we will be able to count the number of triples in a file when that number is higher than two billion.

Travis checks pass, locally it still does the counting thing. Please double check as it is my first (if trivial C code base patch)