### PR TITLE
This changeset fixes an issue with the turtle chunk parser

### DIFF
--- a/src/turtle_parser.y
+++ b/src/turtle_parser.y
@@ -1719,10 +1719,27 @@ raptor_turtle_parse_chunk(raptor_parser* rdf_parser,
         turtle_parser->deferred = NULL;
       }
     }
-  } else if(rdf_parser->emitted_default_graph) {
-    /* for non-TRIG - end default graph after last triple */
-    raptor_parser_end_graph(rdf_parser, NULL, 0);
-    rdf_parser->emitted_default_graph--;
+  } else {
+    /* this was the last chunk, finalise */
+    if(turtle_parser->deferred) {
+      raptor_sequence* def = turtle_parser->deferred;
+      int i;
+      for(i = 0; i < raptor_sequence_size(def); i++) {
+	raptor_statement *t2 = (raptor_statement*)raptor_sequence_get_at(def, i);
+
+	raptor_turtle_handle_statement(rdf_parser, t2);
+      }
+    }
+    if(rdf_parser->emitted_default_graph) {
+      /* for non-TRIG - end default graph after last triple */
+      raptor_parser_end_graph(rdf_parser, NULL, 0);
+      rdf_parser->emitted_default_graph--;
+    }
+    if(turtle_parser->deferred) {
+      /* clear resources */
+      raptor_free_sequence(turtle_parser->deferred);
+      turtle_parser->deferred = NULL;
+    }
   }
   return rc;
 }


### PR DESCRIPTION
which defers statements internally to pick up the work with
the next chunk.  Should the chunk parser not be called
anymore any statements recorded as deferred would be lost.

An example to reproduce the bug (TriG mode):

<x> { [ a <test> ] <shows> <bug> .}

With this fix applied the above correctly produces the
following 2 quads:

_:genid1 <shows> <bug> <x> .
_:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <test> <x> .