### PR TITLE
provide raptor_turtle_serialize_flush()

### DIFF
--- a/src/raptor2.h.in
+++ b/src/raptor2.h.in
@@ -2153,6 +2153,8 @@ void* raptor_avltree_remove(raptor_avltree* tree, void* p_data);
 RAPTOR_API
 int raptor_avltree_delete(raptor_avltree* tree, void* p_data);
 RAPTOR_API
+int raptor_avltree_trim(raptor_avltree* tree);
+RAPTOR_API
 void* raptor_avltree_search(raptor_avltree* tree, const void* p_data);
 RAPTOR_API
 int raptor_avltree_visit(raptor_avltree* tree, raptor_avltree_visit_handler visit_handler, void* user_data);

--- a/src/raptor2.h.in
+++ b/src/raptor2.h.in
@@ -2153,7 +2153,7 @@ void* raptor_avltree_remove(raptor_avltree* tree, void* p_data);
 RAPTOR_API
 int raptor_avltree_delete(raptor_avltree* tree, void* p_data);
 RAPTOR_API
-int raptor_avltree_trim(raptor_avltree* tree);
+void raptor_avltree_trim(raptor_avltree* tree);
 RAPTOR_API
 void* raptor_avltree_search(raptor_avltree* tree, const void* p_data);
 RAPTOR_API

--- a/src/raptor_avltree.c
+++ b/src/raptor_avltree.c
@@ -329,6 +329,23 @@ raptor_avltree_delete(raptor_avltree* tree, void* p_data)
 }
 
 
+/**
+ * raptor_avltree_trim:
+ * @tree: AVLTree object
+ *
+ * Delete all nodes from an AVL tree but keep the shell.
+ */
+void
+raptor_avltree_trim(raptor_avltree* tree)
+{
+  if(!tree)
+    return;
+  
+  raptor_free_avltree_internal(tree, tree->root);
+  tree->root = NULL;
+}
+
+
 static int
 raptor_avltree_visit_internal(raptor_avltree* tree, raptor_avltree_node* node,
                               int depth,

--- a/src/raptor_serialize_turtle.c
+++ b/src/raptor_serialize_turtle.c
@@ -145,6 +145,7 @@ static int raptor_turtle_serialize_statement(raptor_serializer* serializer,
                                              raptor_statement *statement);
 
 static int raptor_turtle_serialize_end(raptor_serializer* serializer);
+static int raptor_turtle_serialize_flush(raptor_serializer* serializer);
 static void raptor_turtle_serialize_finish_factory(raptor_serializer_factory* factory);
 
 
@@ -1471,6 +1472,19 @@ raptor_turtle_serialize_end(raptor_serializer* serializer)
   return 0;
 }
 
+/* flush turtle */
+static int
+raptor_turtle_serialize_flush(raptor_serializer* serializer)
+{
+  raptor_turtle_context* context = (raptor_turtle_context*)serializer->context;
+
+  raptor_turtle_ensure_writen_header(serializer, context);
+
+  raptor_turtle_emit(serializer);
+
+  return 0;
+}
+
 
 /* finish the serializer factory */
 static void
@@ -1528,6 +1542,7 @@ raptor_turtle_serializer_register_factory(raptor_serializer_factory *factory)
   factory->serialize_start     = raptor_turtle_serialize_start;
   factory->serialize_statement = raptor_turtle_serialize_statement;
   factory->serialize_end       = raptor_turtle_serialize_end;
+  factory->serialize_flush     = raptor_turtle_serialize_flush;
   factory->finish_factory      = raptor_turtle_serialize_finish_factory;
 
   return 0;

--- a/src/raptor_serialize_turtle.c
+++ b/src/raptor_serialize_turtle.c
@@ -1482,6 +1482,18 @@ raptor_turtle_serialize_flush(raptor_serializer* serializer)
 
   raptor_turtle_emit(serializer);
 
+  if(context->subjects) {
+    raptor_avltree_trim(context->subjects);
+  }
+
+  if(context->blanks) {
+    raptor_avltree_trim(context->blanks);
+  }
+
+  if(context->nodes) {
+    raptor_avltree_trim(context->nodes);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
This changeset clones raptor_turtle_serialize_end() as
raptor_turtle_serialize_flush() without the reset for the
header.  This, via raptor_serializer_flush(), allows for
fine grained emission of turtle statements.