### PR TITLE
configure.ac: Remove unused LIBXSLT_VERSION variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -603,10 +603,7 @@ if test "X$XSLT_CONFIG" != "X"; then
   CPPFLAGS="$oCPPFLAGS"
   LIBS="$oLIBS"
 else
-  PKG_CHECK_MODULES([XSLT], [libxslt > $libxslt_min_version], [
-    LIBXSLT_VERSION=`$PKG_CONFIG libxslt --modversion`
-    have_libxslt=1
-  ], [have_libxslt=0])
+  PKG_CHECK_MODULES([XSLT], [libxslt > $libxslt_min_version], [have_libxslt=1], [have_libxslt=0])
 fi
 
 dnl curl


### PR DESCRIPTION
When I made the previous change, I mistakenly left the LIBXSLT_VERSION variable in the source code.

It's not used anywhere and can be safely removed.