### PR TITLE
fix the cmake generated pc file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -378,8 +378,8 @@ ENDIF(RAPTOR_PARSER_RDFXML)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/raptor2.pc
 "prefix=${CMAKE_INSTALL_PREFIX}
 exec_prefix=\${prefix}
-libdir=\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}
-includedir=\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}/raptor2
+libdir=${CMAKE_INSTALL_FULL_LIBDIR}
+includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}/raptor2
 
 Name: Raptor RDF Parsing Library
 Description: RDF Parser Toolkit Library


### PR DESCRIPTION
before

libdir=${exec_prefix}//nix/store/i7abvb760gzca1wqk9g617shqdj5sr7f-raptor2-aarch64-unknown-linux-gnu-2.0.15/lib
includedir=${prefix}//nix/store/i7abvb760gzca1wqk9g617shqdj5sr7f-raptor2-aarch64-unknown-linux-gnu-2.0.15/include/raptor2

note the double // due to CMAKE_INSTALL_LIBDIR already being a absolute
path

after

libdir=/nix/store/rlhzlak7chagd23898n1x9id6f5a6qpn-raptor2-aarch64-unknown-linux-gnu-2.0.15/lib
includedir=/nix/store/rlhzlak7chagd23898n1x9id6f5a6qpn-raptor2-aarch64-unknown-linux-gnu-2.0.15/include/raptor2

a in depth explanation is in https://github.com/rnpgp/rnp/issues/1835