### PR TITLE
CMakeLists.txt: default to shared libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ ENDIF(LIBXML2_FOUND)
 # (Note: The CMake GUI displays these in alphabetical order, regardless of
 # the order we use here)
 
-SET(BUILD_SHARED_LIBS OFF CACHE BOOL
+SET(BUILD_SHARED_LIBS ON CACHE BOOL
 	"Build shared libraries instead of static ones.")
 
 IF(BUILD_SHARED_LIBS)


### PR DESCRIPTION
raptor2 provides a library and depends on a few other libraries
on it's own (like libxml2).

Some downstream projects are not very careful to include all
the needed libraries from .pc files and use just raptor2 one.

This sometimes causes linkage failures like `guitarix`:
https://hydra.nixos.org/log/4hznma7pl7wvjdhm3x2lr84zpj07s2ax-guitarix-0.42.1.drv
In this case linkage failure happens via underlinked `liblrdf.so`.

While it's a bug in `liblrdf.so` I think it would be reasonable
to enable shared libraries by default for use in distributions as is.

This change enables shared library by default.