### PR TITLE
configure.ac: fix -Wimplicit-function-declaration in HAVE___FUNCTION_…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,7 +336,7 @@ AC_C_INLINE
 
 AC_MSG_CHECKING(whether __FUNCTION__ is available)
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <stdio.h>
-int main() { printf(__FUNCTION__); }])],
+int main(void) { printf(__FUNCTION__); }])],
     [AC_DEFINE([HAVE___FUNCTION__], [1], [Is __FUNCTION__ available])
      AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)])
@@ -420,7 +420,7 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
-int main() { return strtok_r(); }
+int main(void) { return strtok_r(); }
 ])],
   [AC_MSG_RESULT(yes)
    have_strtok_r=yes

--- a/configure.ac
+++ b/configure.ac
@@ -335,7 +335,8 @@ AC_C_BIGENDIAN
 AC_C_INLINE
 
 AC_MSG_CHECKING(whether __FUNCTION__ is available)
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() { printf(__FUNCTION__); }])],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <stdio.h>
+int main() { printf(__FUNCTION__); }])],
     [AC_DEFINE([HAVE___FUNCTION__], [1], [Is __FUNCTION__ available])
      AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)])


### PR DESCRIPTION
…_ test

This breaks with Clang 16 which makes such errors fatal:
```
error: call to undeclared library function 'printf' with type 'int (const char *, ...)'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
error: call to undeclared library function 'printf' with type 'int (const char *, ...)'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
```

Signed-off-by: Sam James <sam@gentoo.org>