### PR TITLE
configure.ac: Include <stdio.h> for printf in __FUNCTION__ check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -335,7 +335,9 @@ AC_C_BIGENDIAN
 AC_C_INLINE
 
 AC_MSG_CHECKING(whether __FUNCTION__ is available)
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() { printf(__FUNCTION__); }])],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+#include <stdio.h>
+int main() { printf(__FUNCTION__); }])],
     [AC_DEFINE([HAVE___FUNCTION__], [1], [Is __FUNCTION__ available])
      AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)])


### PR DESCRIPTION
Otherwise, the check will fail with compilers which do not implement implicit function declarations (a C feature that was removed in 1999 from the language), no matter if the compiler supports __FUNCTION__ or not.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
