### PR TITLE
Fix sort_r selection on GNU/Hurd

### DIFF
--- a/src/sort_r.h
+++ b/src/sort_r.h
@@ -19,7 +19,7 @@ void sort_r(void *base, size_t nel, size_t width,
             void *arg);
 */
 
-#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
+#if (defined __APPLE__ || defined __DARWIN__ || \
      defined __FreeBSD__ || defined __BSD__ || defined __bsdi__ || \
      defined OpenBSD3_1 || defined OpenBSD3_9 || defined __OpenBSD__ || \
      defined __NetBSD__ || \


### PR DESCRIPTION
The Hurd is based on the Mach microkernel, and thus `__MACH__` is defined; since also macOS is (loosely) based on Mach, it defines `__MACH__` as well. Because of this, the wrong variant of `sort_r` (i.e. the BSD one) is used for the Hurd, which does not work.

Since on macOS `__APPLE__` is defined, and `__DARWIN__` helps for older Mac OS X, then simply drop the `__MACH__` selection: the preprocessor check for the Linux `sort_r` is properly used for the Hurd (using `__GNU__`), and that variant works fine.