### PR TITLE
correct turtle serialization for collections on depth 0

### DIFF
--- a/src/raptor_serialize_turtle.c
+++ b/src/raptor_serialize_turtle.c
@@ -883,6 +883,7 @@ raptor_turtle_emit_subject(raptor_serializer *serializer,
 
     if(pred1->term->type == RAPTOR_TERM_TYPE_URI &&
        pred2->term->type == RAPTOR_TERM_TYPE_URI &&
+       depth > 0 &&
        (
         (raptor_uri_equals(pred1->term->value.uri, context->rdf_first_uri) &&
          raptor_uri_equals(pred2->term->value.uri, context->rdf_rest_uri))

--- a/tests/turtle/Makefile.am
+++ b/tests/turtle/Makefile.am
@@ -31,7 +31,8 @@ test-14.ttl test-15.ttl test-16.ttl test-17.ttl test-18.ttl \
 test-19.ttl test-20.ttl test-21.ttl test-22.ttl test-23.ttl \
 test-24.ttl test-25.ttl test-26.ttl test-27.ttl \
 test-29.ttl test-30.ttl test-33.ttl test-36.ttl test-37.ttl \
-test-38.ttl bad-15.ttl bad-17.ttl bad-18.ttl bad-21.ttl bad-22.ttl \
+test-38.ttl test-40.ttl \
+bad-15.ttl bad-17.ttl bad-18.ttl bad-21.ttl bad-22.ttl \
 rdf-schema.ttl \
 rdfs-namespace.ttl \
 rdfq-results.ttl
@@ -49,7 +50,8 @@ test-14.out test-15.out test-16.out test-17.out test-18.out \
 test-19.out test-20.out test-21.out test-22.out test-23.out \
 test-24.out test-25.out test-26.out test-27.out test-28.out \
 test-29.out test-30.out test-33.out test-36.out test-37.out \
-test-38.out bad-15.out bad-17.out bad-18.out bad-21.out bad-22.out \
+test-38.out test-40.out \
+bad-15.out bad-17.out bad-18.out bad-21.out bad-22.out \
 rdf-schema.out \
 rdfs-namespace.out \
 rdfq-results.out

--- a/tests/turtle/test-40.out
+++ b/tests/turtle/test-40.out
@@ -1,0 +1,6 @@
+_:genid1 <http://example.com/prop> _:Ne7d .
+_:genid2 <http://example.com/prop> _:Ne7d .
+_:N849 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.com/b> .
+_:N849 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:Ne7d <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.com/a> .
+_:Ne7d <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:N849 .

--- a/tests/turtle/test-40.ttl
+++ b/tests/turtle/test-40.ttl
@@ -1,0 +1,12 @@
+@prefix ns1: <http://example.com/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+[] ns1:prop _:Ne7d .
+
+[] ns1:prop _:Ne7d .
+
+_:N849 rdf:first ns1:b ;
+    rdf:rest () .
+
+_:Ne7d rdf:first ns1:a ;
+    rdf:rest _:N849 .


### PR DESCRIPTION
test and fix for #73

description of fix:
disable identification as collection when emitting a collection as base.

log:
issue with emitting serialization of list on depth 0. Implemented test and fix.