### PR TITLE
raptor_turtle_parse_chunk: update turtle_parser->consumed on the last chunk

### DIFF
--- a/src/turtle_parser.y
+++ b/src/turtle_parser.y
@@ -1774,7 +1774,8 @@ raptor_turtle_parse_chunk(raptor_parser* rdf_parser,
       }
     }
   } else {
-    /* this was the last chunk, finalise */
+    /* this was the last chunk, empty the buffer and finalise */
+    turtle_parser->consumed = 0;
     if(turtle_parser->deferred) {
       raptor_sequence* def = turtle_parser->deferred;
       int i;


### PR DESCRIPTION
When it's not the last chunk, any data that hasn't been consumed is moved to the start of the buffer, and ->consumed is set to the length. However, ->consumed wasn't being reset for the last chunk - so if you reused a turtle parser after feeding a last chunk through it, the state would be inconsistent: the next chunk would get copied after the data from the previous chunk, but the parser would read from the start of the buffer...

To fix this, just set ->consumed to 0 after the last chunk, so the buffer gets cleared.

This fixes a failure in librdf's rdf_parser test, which feeds several strings through the same parser: the "Adding turtle counted string" test produces "librdf error XXX - syntax error at XXX" with XXX being binary garbage as the parser ran off the end of the buffer. (It's a bit more obvious for me if you build raptor/librdf with `-fsanitize=address`, since then you get a long string of ASan's uninitialised memory filler character.)

I supect it's the same as this problem: https://bugs.librdf.org/mantis/view.php?id=597