### PR TITLE
cmake use python3 instead of perl scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ FIND_PACKAGE(CURL)
 FIND_PACKAGE(LibXml2)
 FIND_PACKAGE(LibXslt)
 #FIND_PACKAGE(YAJL)
-FIND_PACKAGE(Perl REQUIRED)
+#FIND_PACKAGE(Perl REQUIRED)
+FIND_PACKAGE(Python3 REQUIRED)
 FIND_PACKAGE(BISON 3.4 REQUIRED)
 FIND_PACKAGE(FLEX 2.5.19 REQUIRED)
 
@@ -310,7 +311,7 @@ Raptor Configuration Summary
     "
 )
 
-message( "  *** Perl                        ${PERL_EXECUTABLE}")
+message( "  *** Python                      ${Python3_EXECUTABLE}")
 message( "  *** Bison                       ${BISON_EXECUTABLE}")
 message( "  *** Flex                        ${FLEX_EXECUTABLE}")
 message( "  *** libxml2 (lib)               ${LIBXML2_LIBRARIES}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ IF(RAPTOR_PARSER_TURTLE OR RAPTOR_PARSER_TRIG)
 
   ADD_CUSTOM_TARGET(turtle_parser_tgt DEPENDS turtle_tables_tgt ${CMAKE_CURRENT_BINARY_DIR}/turtle_parser.c ${CMAKE_CURRENT_BINARY_DIR}/turtle_parser.h)
   ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/turtle_parser.c
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-bison.pl ${CMAKE_CURRENT_BINARY_DIR}/turtle_parser.c
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-bison.py ${CMAKE_CURRENT_BINARY_DIR}/turtle_parser.c
     DEPENDS turtle_tables_tgt)
 
   # Generate the turtle lexer
@@ -52,8 +52,8 @@ IF(RAPTOR_PARSER_TURTLE OR RAPTOR_PARSER_TRIG)
 
   ADD_CUSTOM_TARGET(turtle_lexer_tgt DEPENDS turtle_flex_tgt)
   ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.c
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-flex.pl ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.t > ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.c
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-flex.pl ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.h > ${CMAKE_CURRENT_BINARY_DIR}/t
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-flex.py ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.t > ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.c
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-flex.py ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.h > ${CMAKE_CURRENT_BINARY_DIR}/t
     COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/t ${CMAKE_CURRENT_BINARY_DIR}/turtle_lexer.h
     DEPENDS turtle_flex_tgt)
 ENDIF(RAPTOR_PARSER_TURTLE OR RAPTOR_PARSER_TRIG)
@@ -169,7 +169,7 @@ IF(RAPTOR_PARSEDATE)
 
   ADD_CUSTOM_TARGET(parsedate_tgt DEPENDS parsedate_tables_tgt ${CMAKE_CURRENT_BINARY_DIR}/parsedate.c ${CMAKE_CURRENT_BINARY_DIR}/parsedate.h)
   ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/parsedate.c
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-bison.pl ${CMAKE_CURRENT_BINARY_DIR}/parsedate.c
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/fix-bison.py ${CMAKE_CURRENT_BINARY_DIR}/parsedate.c
     DEPENDS parsedate_tables_tgt)
 ENDIF(RAPTOR_PARSEDATE)
 


### PR DESCRIPTION
perl scripts were already replaced with python scripts. This will change only cmakes behaviour to generate `turtle_lexer.c` `turtle_parser.c` and `parsedate.c` with those python scripts. Removes perl as package and adds python3 as package to cmake.

Tested with :
```bash
cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DRAPTOR_PARSER_TURTLE=TRUE -DRAPTOR_PARSER_RDFA=TRUE -DRAPTOR_PARSER_RDFXML=TRUE -DRAPTOR_PARSER_NTRIPLES=TRUE -DRAPTOR_PARSER_NQUADS=TRUE -DRAPTOR_PARSER_TRIG=TRUE -S raptor/ -B qq/
cmake --build qq/
cd qq/
make test
```