### PR TITLE
write turtle as longstring for string containing CR

### DIFF
--- a/src/raptor_turtle_writer.c
+++ b/src/raptor_turtle_writer.c
@@ -240,12 +240,12 @@ raptor_free_turtle_writer(raptor_turtle_writer* turtle_writer)
 
 
 static int
-raptor_turtle_writer_contains_newline(const unsigned char *s, size_t len)
+raptor_turtle_writer_contains_newline_or_carriage_return(const unsigned char *s, size_t len)
 {
   size_t i = 0;
 
   for( ; i < len; i++)
-    if(s[i] == '\n')
+    if(s[i] == '\n' || s[i] == '\r')
       return 1;
 
   return 0;
@@ -407,7 +407,7 @@ raptor_turtle_writer_quoted_counted_string(raptor_turtle_writer* turtle_writer,
     return 1;
   
   /* Turtle """longstring""" (2) or "string" (1) */
-  if(raptor_turtle_writer_contains_newline(s, len)) {
+  if(raptor_turtle_writer_contains_newline_or_carriage_return(s, len)) {
     /* long string */
     flags = RAPTOR_ESCAPED_WRITE_TURTLE_LONG_LITERAL;
     q = quotes;


### PR DESCRIPTION
Hi,

It looks like serialization to turtle of a carriage return doesn't escape the carriage return, nor does it triple-quote it. The [turtle spec](https://www.w3.org/TR/turtle/) states that
>Literals delimited by ", may not contain the characters ", LF, or CR. 

```
# hexdump -C cr.nq
00000000  3c 68 74 74 70 3a 2f 2f  61 3e 20 3c 68 74 74 70  |<http://a> <http|
00000010  3a 2f 2f 62 3e 20 22 5c  72 22 20 3c 68 74 74 70  |://b> "\r" <http|
00000020  3a 2f 2f 67 3e 20 2e 0a                           |://g> ..|
00000028

# rapper -v
2.0.16

# rapper --input nquads cr.nq --output turtle > cr.ttl
rapper: Parsing URI file:///data/shacl-docker/cr.nq with parser nquads
rapper: Serializing with serializer turtle
rapper: Parsing returned 1 triple

# hexdump -C cr.ttl
00000000  40 70 72 65 66 69 78 20  72 64 66 3a 20 3c 68 74  |@prefix rdf: <ht|
00000010  74 70 3a 2f 2f 77 77 77  2e 77 33 2e 6f 72 67 2f  |tp://www.w3.org/|
00000020  31 39 39 39 2f 30 32 2f  32 32 2d 72 64 66 2d 73  |1999/02/22-rdf-s|
00000030  79 6e 74 61 78 2d 6e 73  23 3e 20 2e 0a 0a 3c 68  |yntax-ns#> ...<h|
00000040  74 74 70 3a 2f 2f 61 3e  0a 20 20 20 20 3c 68 74  |ttp://a>.    <ht|
00000050  74 70 3a 2f 2f 62 3e 20  22 0d 22 20 2e 0a 0a     |tp://b> "." ...|
0000005f
```
The quotes case is covered in https://github.com/dajobe/raptor/blob/b1959b61737e4d52328ccfac67d0cc7b64dfcda4/src/raptor_escaped.c#L67-L72
The newline case is covered in 
https://github.com/dajobe/raptor/blob/b1959b61737e4d52328ccfac67d0cc7b64dfcda4/src/raptor_turtle_writer.c#L410-L415
This PR extends the newline-test in order to cover carriage return as well. Still needs testing and reviewing.